### PR TITLE
Rm thiserror

### DIFF
--- a/prae/Cargo.toml
+++ b/prae/Cargo.toml
@@ -14,7 +14,6 @@ categories = ["development-tools"]
 [dependencies]
 prae_macro = { version = "0.2.1", path = "../prae_macro" }
 serde = { version = "1.0.126", optional = true }
-thiserror = "1.0.25"
 
 [dev-dependencies]
 serde_json = "1.0.64"

--- a/prae/src/core.rs
+++ b/prae/src/core.rs
@@ -1,15 +1,25 @@
 use core::hash::Hash;
-use std::{
-    fmt::Debug,
-    ops::{Deref, Index},
-};
-use thiserror::Error;
+use std::fmt;
+use std::ops::{Deref, Index};
 
 /// Default validation error. It is used for [`define!`](prae_macro::define) macro with `ensure`
 /// keyword.
-#[derive(Debug, PartialEq, Error)]
-#[error("provided value is not valid")]
+#[derive(PartialEq)]
 pub struct ValidationError;
+
+impl std::error::Error for ValidationError {}
+
+impl fmt::Debug for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "provided value is not valid")
+    }
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "provided value is not valid")
+    }
+}
 
 /// A trait that represents a guard bound, e.g. a type that is being guarded, `adjust`/`validate`
 /// functions and a possible validation error.
@@ -33,7 +43,7 @@ pub struct Guarded<G: Guard>(G::Target);
 
 impl<T, E, G> Guarded<G>
 where
-    E: std::fmt::Debug,
+    E: fmt::Debug,
     G: Guard<Target = T, Error = E>,
 {
     /// Constructor. Will return an error if the provided argument `v`


### PR DESCRIPTION
Using `thiserror` for defining one error is overkill. Why not remove it and save yourself a dependency?