### PR TITLE
Introduce `ConstructionError<G>` and `MutationError<G>`

### DIFF
--- a/prae/Cargo.toml
+++ b/prae/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prae"
-version = "0.4.5"
+version = "0.5.0"
 authors = ["Alex Ryapolov <ryapolov@pm.me>"]
 edition = "2018"
 license = "Unlicense"
@@ -12,7 +12,7 @@ keywords = ["validation", "macro", "invariant", "generation"]
 categories = ["development-tools"]
 
 [dependencies]
-prae_macro = { version = "0.2", path = "../prae_macro" }
+prae_macro = { version = "0.3", path = "../prae_macro" }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/prae/src/core.rs
+++ b/prae/src/core.rs
@@ -31,7 +31,7 @@ where
         write!(
             f,
             "failed to create {} from value {:?}: {}",
-            guard_alias_name::<G>(),
+            G::alias_name(),
             self.value,
             self.inner,
         )
@@ -77,7 +77,7 @@ where
         write!(
             f,
             "failed to mutate {} from value {:?} to {:?}: {}",
-            guard_alias_name::<G>(),
+            G::alias_name(),
             self.old_value,
             self.new_value,
             self.inner,
@@ -93,13 +93,6 @@ where
 {
 }
 
-/// Dirty hack to get "Name" instead of "module::NameGuard".
-fn guard_alias_name<G>() -> &'static str {
-    let type_name = std::any::type_name::<G>();
-    let i = type_name.rfind(':').unwrap(); // last occurance of ":" in "some::path::NameGuard"
-    type_name[i + 1..].trim_end_matches("Guard")
-}
-
 /// A trait that represents a guard bound, e.g. a type that is being guarded, `adjust`/`validate`
 /// functions and a possible validation error.
 pub trait Guard {
@@ -113,6 +106,10 @@ pub trait Guard {
     /// A function that validates provided value. If the value
     /// is not valid, it returns `Some(Self::Error)`.
     fn validate(v: &Self::Target) -> Option<Self::Error>;
+    /// Helper method for useful error representation.
+    fn alias_name() -> &'static str {
+        std::any::type_name::<Self>()
+    }
 }
 
 /// A thin wrapper around the underlying type and the [`Guard`](Guard) bounded to it. It guarantees

--- a/prae/src/core.rs
+++ b/prae/src/core.rs
@@ -1,33 +1,103 @@
 use core::hash::Hash;
 use std::ops::{Deref, Index};
-use std::{error::Error, fmt};
+use std::{error, fmt};
 
-/// Used for [`define!`](prae_macro::define) macro with `ensure` keyword.
-#[derive(Clone, Debug)]
-pub struct ValidationError {
-    /// The name of the type where this error originated.
-    type_name: &'static str,
-    /// Stringified value that caused the error.
-    value: String,
+/// An error occured during [construction](Guarded::new).
+#[derive(Debug)]
+pub struct ConstructionError<G: Guard> {
+    /// Original error in case of calling [`define!`](prae_macro::define) with `validate` or just a
+    /// string in case of `ensure`.
+    pub inner: G::Error,
+    /// The value that caused the error.
+    pub value: G::Target,
 }
 
-impl ValidationError {
-    /// Create a new error with the input value that failed.
-    pub fn new(type_name: &'static str, value: String) -> Self {
-        ValidationError { type_name, value }
-    }
-}
+// FIXME: the compiler thinks that `G::Error` can be `ConstructionError<G>`,
+// which conflicts with default implementation From<T> for T.
+// I have no idea how to fix it!
+// impl<G: Guard> From<ConstructionError<G>> for G::Error {
+//     fn from(err: ConstructionError<G>) -> Self {
+//         err.inner
+//     }
+// }
 
-impl Error for ValidationError {}
-
-impl fmt::Display for ValidationError {
+impl<G: Guard> fmt::Display for ConstructionError<G>
+where
+    G::Error: fmt::Debug + fmt::Display,
+    G::Target: fmt::Debug,
+    G: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "failed to create {} from value {}: provided value is invalid",
-            self.type_name, self.value,
+            "failed to create {} from value {:?}: {}",
+            guard_alias_name::<G>(),
+            self.value,
+            self.inner,
         )
     }
+}
+
+impl<G: Guard> error::Error for ConstructionError<G>
+where
+    G::Error: fmt::Debug + fmt::Display,
+    G::Target: fmt::Debug,
+    G: fmt::Debug,
+{
+}
+
+/// An error occured during [mutation](Guarded::try_mutate).
+#[derive(Debug)]
+pub struct MutationError<G: Guard> {
+    /// Original error in case of calling [`define!`](prae_macro::define) with `validate` or just a
+    /// string in case of `ensure`.
+    pub inner: G::Error,
+    /// The value before mutation.
+    pub old_value: G::Target,
+    /// The value that caused the error.
+    pub new_value: G::Target,
+}
+
+// FIXME: the compiler thinks that `G::Error` can be `MutationError<G>`,
+// which conflicts with default implementation From<T> for T.
+// I have no idea how to fix it!
+// impl<G: Guard> From<MutationError<G>> for G::Error {
+//     fn from(err: MutationError<G>) -> Self {
+//         err.inner
+//     }
+// }
+
+impl<G: Guard> fmt::Display for MutationError<G>
+where
+    G::Error: fmt::Debug + fmt::Display,
+    G::Target: fmt::Debug,
+    G: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "failed to mutate {} from value {:?} to {:?}: {}",
+            guard_alias_name::<G>(),
+            self.old_value,
+            self.new_value,
+            self.inner,
+        )
+    }
+}
+
+impl<G: Guard> error::Error for MutationError<G>
+where
+    G::Error: fmt::Debug + fmt::Display,
+    G::Target: fmt::Debug,
+    G: fmt::Debug,
+{
+}
+
+/// Dirty hack to get "Name" instead of "module::NameGuard".
+fn guard_alias_name<G>() -> &'static str {
+    let type_name = std::any::type_name::<G>();
+    let i = type_name.rfind(':').unwrap(); // last occurance of ":" in "some::path::NameGuard"
+    type_name[i + 1..].trim_end_matches("Guard")
 }
 
 /// A trait that represents a guard bound, e.g. a type that is being guarded, `adjust`/`validate`
@@ -57,11 +127,13 @@ where
 {
     /// Constructor. Will return an error if the provided argument `v`
     /// doesn't pass the validation.
-    pub fn new<V: Into<T>>(v: V) -> Result<Self, E> {
+    pub fn new<V: Into<T>>(v: V) -> Result<Self, ConstructionError<G>> {
         let mut v: T = v.into();
         G::adjust(&mut v);
-        G::validate(&v).map_or(Ok(()), Err)?;
-        Ok(Self(v))
+        match G::validate(&v) {
+            None => Ok(Self(v)),
+            Some(e) => Err(ConstructionError { inner: e, value: v }),
+        }
     }
 
     /// Returns a shared reference to the inner value.
@@ -84,16 +156,24 @@ where
 
     /// Mutates current value using provided closure. Will return an error if
     /// the result of the mutation is invalid.
-    pub fn try_mutate(&mut self, f: impl FnOnce(&mut T)) -> Result<(), E>
+    pub fn try_mutate(&mut self, f: impl FnOnce(&mut T)) -> Result<(), MutationError<G>>
     where
         T: Clone,
     {
         let mut cloned = self.0.clone();
         f(&mut cloned);
         G::adjust(&mut cloned);
-        G::validate(&cloned).map_or(Ok(()), Err)?;
-        self.0 = cloned;
-        Ok(())
+        match G::validate(&cloned) {
+            None => {
+                self.0 = cloned;
+                Ok(())
+            }
+            Some(e) => Err(MutationError {
+                inner: e,
+                old_value: self.0.clone(),
+                new_value: cloned,
+            }),
+        }
     }
 
     /// Retrieve the inner, unprotected value.

--- a/prae/src/core.rs
+++ b/prae/src/core.rs
@@ -12,6 +12,13 @@ pub struct ConstructionError<G: Guard> {
     pub value: G::Target,
 }
 
+impl<G: Guard> ConstructionError<G> {
+    /// Get inner error.
+    pub fn into_inner(self) -> G::Error {
+        self.inner
+    }
+}
+
 // FIXME: the compiler thinks that `G::Error` can be `ConstructionError<G>`,
 // which conflicts with default implementation From<T> for T.
 // I have no idea how to fix it!
@@ -56,6 +63,13 @@ pub struct MutationError<G: Guard> {
     pub old_value: G::Target,
     /// The value that caused the error.
     pub new_value: G::Target,
+}
+
+impl<G: Guard> MutationError<G> {
+    /// Get inner error.
+    pub fn into_inner(self) -> G::Error {
+        self.inner
+    }
 }
 
 // FIXME: the compiler thinks that `G::Error` can be `MutationError<G>`,

--- a/prae/src/lib.rs
+++ b/prae/src/lib.rs
@@ -46,7 +46,7 @@
 //! mutation fails. Altough it's convenient, there are situations when you might
 //! want to return a custom error. And `prae` can help with this:
 //! ```
-//! #[derive(Debug)]
+//! #[derive(Debug, PartialEq, Eq)]
 //! pub struct UsernameError;
 //!
 //! prae::define! {
@@ -61,7 +61,10 @@
 //!     }
 //! }
 //!
-//! assert!(matches!(Username::new("  "), Err(UsernameError)));
+//! assert!(matches!(
+//!     Username::new("  "),
+//!     Err(prae::ConstructionError { inner, .. }) if inner == UsernameError {}
+//! ));
 //! ```
 
 #![warn(missing_debug_implementations)]

--- a/prae/src/lib.rs
+++ b/prae/src/lib.rs
@@ -38,12 +38,12 @@
 //! assert_eq!(u.get(), "valid name"); // now we're talking!
 //!
 //! // This also works for mutations:
-//! assert!(matches!(u.try_mutate(|u| *u = "   ".to_owned()), Err(prae::ValidationError { .. })));
+//! assert!(matches!(u.try_mutate(|u| *u = "   ".to_owned()), Err(prae::MutationError { .. })));
 //! ```
 //! Now our `Username` trims provided value automatically.
 //!
-//! You might noticed that `prae::ValidationError` is returned by default when our
-//! construction/mutation fails. Altough it's convenient, there are situations when you might
+//! You might noticed that `prae::MutationError` is returned by default when our
+//! mutation fails. Altough it's convenient, there are situations when you might
 //! want to return a custom error. And `prae` can help with this:
 //! ```
 //! #[derive(Debug)]

--- a/prae/tests/adjust_ensure.rs
+++ b/prae/tests/adjust_ensure.rs
@@ -10,10 +10,7 @@ prae::define! {
 
 #[test]
 fn construction_fails_for_invalid_data() {
-    assert_matches!(
-        Username::new("  ").unwrap_err(),
-        prae::ValidationError { .. }
-    )
+    assert_matches!(Username::new("  "), Err(prae::ConstructionError { .. }))
 }
 
 #[test]
@@ -26,8 +23,8 @@ fn construction_succeeds_for_valid_data() {
 fn mutation_fails_for_invalid_data() {
     let mut un = Username::new("user").unwrap();
     assert_matches!(
-        un.try_mutate(|u| *u = "  ".to_owned()).unwrap_err(),
-        prae::ValidationError { .. }
+        un.try_mutate(|u| *u = "  ".to_owned()),
+        Err(prae::MutationError { .. })
     )
 }
 

--- a/prae/tests/adjust_validate.rs
+++ b/prae/tests/adjust_validate.rs
@@ -19,7 +19,7 @@ prae::define! {
 
 #[test]
 fn construction_fails_for_invalid_data() {
-    assert_matches!(Username::new("  ").unwrap_err(), UsernameError {});
+    assert_matches!(Username::new("  "), Err(prae::ConstructionError { .. }));
 }
 
 #[test]
@@ -32,8 +32,8 @@ fn construction_succeeds_for_valid_data() {
 fn mutation_fails_for_invalid_data() {
     let mut un = Username::new("user").unwrap();
     assert_matches!(
-        un.try_mutate(|u| *u = "  ".to_owned()).unwrap_err(),
-        UsernameError {}
+        un.try_mutate(|u| *u = "  ".to_owned()),
+        Err(prae::MutationError { .. })
     );
 }
 

--- a/prae/tests/ensure.rs
+++ b/prae/tests/ensure.rs
@@ -8,21 +8,27 @@ prae::define! {
 }
 
 #[test]
-fn construction_fails_for_invalid_data() {
-    assert_matches!(
-        Username::new("").unwrap_err(),
-        prae::ValidationError { .. }
-    )
+fn construction_error_formats_correctly() {
+    let err = Username::new("").unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "failed to create Username from value \"\": provided value is invalid"
+    );
 }
 
 #[test]
-fn error_formats_correctly() {
-    let error = Username::new("").unwrap_err();
-    let message = format!("{}", error);
+fn mutation_error_formats_correctly() {
+    let mut un = Username::new("user").unwrap();
+    let err = un.try_mutate(|u| *u = "".to_owned()).unwrap_err();
     assert_eq!(
-        message,
-        "failed to create Username from value \"\": provided value is invalid"
+        err.to_string(),
+        "failed to mutate Username from value \"user\" to \"\": provided value is invalid"
     );
+}
+
+#[test]
+fn construction_fails_for_invalid_data() {
+    assert_matches!(Username::new(""), Err(prae::ConstructionError { .. }));
 }
 
 #[test]
@@ -35,8 +41,8 @@ fn construction_succeeds_for_valid_data() {
 fn mutation_fails_for_invalid_data() {
     let mut un = Username::new("user").unwrap();
     assert_matches!(
-        un.try_mutate(|u| *u = "".to_owned()).unwrap_err(),
-        prae::ValidationError { .. }
+        un.try_mutate(|u| *u = "".to_owned()),
+        Err(prae::MutationError { .. })
     )
 }
 

--- a/prae/tests/validate.rs
+++ b/prae/tests/validate.rs
@@ -44,7 +44,7 @@ fn mutation_error_formats_correctly() {
 #[test]
 fn construction_error_can_be_transormed_into_inner() {
     let _err = || -> Result<(), UsernameError> {
-        Username::new("")?;
+        Username::new("").map_err(|e| e.into_inner())?;
         Ok(())
     }();
 }
@@ -53,7 +53,8 @@ fn construction_error_can_be_transormed_into_inner() {
 fn mutation_error_can_be_transormed_into_inner() {
     let _err = || -> Result<(), UsernameError> {
         let mut un = Username::new("user").unwrap();
-        un.try_mutate(|u| *u = "".to_owned())?;
+        un.try_mutate(|u| *u = "".to_owned())
+            .map_err(|e| e.into_inner())?;
         Ok(())
     }();
 }

--- a/prae_macro/Cargo.toml
+++ b/prae_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prae_macro"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Alex Ryapolov <ryapolov@pm.me>"]
 edition = "2018"
 license = "Unlicense"

--- a/prae_macro/src/lib.rs
+++ b/prae_macro/src/lib.rs
@@ -61,6 +61,7 @@ pub fn define(input: TokenStream) -> TokenStream {
             type Error = #err_ty;
             #adjust_fn
             #validate_fn
+            fn alias_name() -> &'static str { stringify!(#ident) }
         }
         #vis type #ident = prae::Guarded<#guard_ident>;
     };

--- a/prae_macro/src/lib.rs
+++ b/prae_macro/src/lib.rs
@@ -34,9 +34,9 @@ pub fn define(input: TokenStream) -> TokenStream {
 
     let validate_fn = match &guard {
         GuardClosure::Ensure(EnsureClosure(closure)) => quote! {
-            fn validate(v: &Self::Target) -> Option<prae::ValidationError> {
+            fn validate(v: &Self::Target) -> Option<&'static str> {
                 let f: fn(&Self::Target) -> bool = #closure;
-                if f(v) { None } else { Some(prae::ValidationError::new(stringify!(#ident), format!("{:?}", v))) }
+                if f(v) { None } else { Some("provided value is invalid") }
             }
         },
         GuardClosure::Validate(ValidateClosure(closure, err_ty)) => quote! {
@@ -48,7 +48,7 @@ pub fn define(input: TokenStream) -> TokenStream {
     };
 
     let err_ty = match &guard {
-        GuardClosure::Ensure(_) => quote!(prae::ValidationError),
+        GuardClosure::Ensure(_) => quote!(&'static str),
         GuardClosure::Validate(ValidateClosure(_, err_ty)) => quote!(#err_ty),
     };
 


### PR DESCRIPTION
This branch introduces two errors:
- `ConstructionError<G>` which will be returned from `Guarded::new`
- `MutationError<G>` which will be returned from `Guarded::try_mutate`