### PR TITLE
Fix serde tests

### DIFF
--- a/prae/tests/serde_integration.rs
+++ b/prae/tests/serde_integration.rs
@@ -1,46 +1,49 @@
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+mod tests {
+    use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
-struct User {
-    name: Username,
-}
-
-prae::define! {
-    Username: String
-    adjust |u| *u = u.trim().to_owned()
-    ensure |u| !u.is_empty()
-}
-
-#[test]
-fn deserialization_succeeds_with_valid_data() {
-    let json = r#"
-    {
-        "name": "   some name   "
+    #[derive(Debug, Serialize, Deserialize)]
+    struct User {
+        name: Username,
     }
-    "#;
-    let u: User = serde_json::from_str(json).unwrap();
-    assert_eq!(u.name.get(), "some name");
-}
 
-#[test]
-fn deserialization_fails_with_nvalid_data() {
-    let json = r#"
-    {
-        "name": "     "
+    prae::define! {
+        Username: String
+        adjust |u| *u = u.trim().to_owned()
+        ensure |u| !u.is_empty()
     }
-    "#;
-    let err = serde_json::from_str::<User>(json).unwrap_err();
-    assert_eq!(
-        err.to_string(),
-        "failed to create Username from value \"\": provided value is invalid at line 4 column 5"
-    );
-}
 
-#[test]
-fn serialization_succeeds() {
-    let u = User {
-        name: Username::new("some name").unwrap(),
-    };
-    let json = serde_json::to_string(&u).unwrap();
-    assert_eq!(r#"{"name":"some name"}"#, json)
+    #[test]
+    fn deserialization_succeeds_with_valid_data() {
+        let json = r#"
+        {
+            "name": "   some name   "
+        }
+        "#;
+        let u: User = serde_json::from_str(json).unwrap();
+        assert_eq!(u.name.get(), "some name");
+    }
+
+    #[test]
+    fn deserialization_fails_with_invalid_data() {
+        let json = r#"
+        {
+            "name": "     "
+        }
+        "#;
+        let err = serde_json::from_str::<User>(json).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "failed to create Username from value \"\": provided value is invalid at line 4 column 9"
+        );
+    }
+
+    #[test]
+    fn serialization_succeeds() {
+        let u = User {
+            name: Username::new("some name").unwrap(),
+        };
+        let json = serde_json::to_string(&u).unwrap();
+        assert_eq!(r#"{"name":"some name"}"#, json)
+    }
 }

--- a/prae/tests/tests.rs
+++ b/prae/tests/tests.rs
@@ -3,6 +3,5 @@ mod adjust_ensure;
 mod adjust_validate;
 mod ensure;
 mod non_clone;
-#[cfg(feature = "serde")]
 mod serde_integration;
 mod validate;


### PR DESCRIPTION
The conditional inclusion of the serde_integration mod doesn't work as expected. The mods code is still compiled in when the serde feature isn't specified. 